### PR TITLE
neutral output at end of `MoveClimber`

### DIFF
--- a/src/main/java/frc/robot/commands/Climber/MoveClimber.java
+++ b/src/main/java/frc/robot/commands/Climber/MoveClimber.java
@@ -46,6 +46,7 @@ public class MoveClimber extends CommandBase {
 
   @Override
   public void end(boolean interrupted) {
+    subClimber.neutralMotorOutput();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -134,6 +134,10 @@ public class Climber extends SubsystemBase {
 
   };
 
+  public void neutralMotorOutput() {
+    climberMotor.neutralOutput();
+  }
+
   public boolean isAngled() {
     return pivotPiston.isDeployed();
   }


### PR DESCRIPTION
closes #93 