### PR TITLE
streamlined shooter controls

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -110,12 +110,10 @@ public class RobotContainer {
     // Operator Commands
 
     // Shooting
-    conOperator.btn_RTrig
-        .whileHeld(comShootCargo)
-        .whileHeld(() -> subShooter.setMotorRPMToGoalRPM())
-        .whenReleased(() -> subShooter.neutralOutput());
+    conOperator.btn_RTrig.whileHeld(comShootCargo);
 
-    conOperator.btn_RBump.whenPressed(() -> subShooter.setMotorRPMToGoalRPM());
+    conOperator.btn_RBump.whenPressed(new RunCommand(() -> subShooter.setMotorRPMToGoalRPM()));
+    conOperator.btn_Start.whenPressed(() -> subShooter.neutralOutput());
 
     // Turret
     conOperator.btn_LBump.whileHeld(comMoveTurret);


### PR DESCRIPTION
with better vision/odometry aiming the shooter, the shooter flywheel has to constantly be changing its setpoint to track the goal rpm. with the old controls this would be a little janky (would have to spam RB). proposed changes would make it so pressing RB once would set the flywheel to consistently track the goal rpm. this also makes RT not control the flywheel at all. to make it possible to spin down the flywheel start will neutral output.

I'm pretty sure the shooter can run constantly without battery draw concerns. this would allow the operator to not worry about spinning up the flywheel, which could speed up cycle times.

this could also mean that instead of implementing a shooter buffer in ShootCargo, the operator could just let go of RT momentarily after shooting one cargo